### PR TITLE
Add updateRewardPerBlock back

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -260,6 +260,20 @@ contract GamersePool is Ownable, ReentrancyGuard {
         emit AdminTokenRecovery(_tokenAddress, _tokenAmount);
     }
 
+    /*
+     * @notice Update reward per block
+     * @dev Only callable by owner.
+     * @param _rewardPerBlock: the reward per block
+     */
+    function updateRewardPerBlock(uint256 _rewardPerBlock) external onlyOwner {
+        require(block.number < startBlock, "Pool has started");
+
+        _updatePool();
+
+        rewardPerBlock = _rewardPerBlock;
+        emit NewRewardPerBlock(_rewardPerBlock);
+    }
+
     /**
      * @notice It allows the admin to update start and end blocks
      * @dev This function is only callable by owner.


### PR DESCRIPTION
Khaled and audit agree can add the `updateRewardPerBlock` back, incase we need to extend the pool.